### PR TITLE
Docker image CUDA 12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.1.0-devel-ubuntu22.04
+FROM nvidia/cuda:12.2.0-devel-ubuntu22.04
 
 ARG PYTORCH_VERSION=2.2.2
 ARG PYTHON_VERSION=3.9


### PR DESCRIPTION
The base image should be based on CUDA 12.2 so that things work on the cluster.